### PR TITLE
Add release instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,20 @@ make deb
 make arch
 ```
 
+## Releasing
+
+To create a new release, update these files with the new version:
+
+1. `otpversion.py` - update `program_version`
+2. `pyproject.toml` - update version in both `[project]` and `[tool.poetry]` sections
+3. `CHANGELOG.md` - add new release section (template format, parsed by `tools/debian-changelog-generator.py`)
+
+After merging to `main`, tag and push to trigger CI release:
+```bash
+git tag X.Y.Z
+git push origin X.Y.Z
+```
+
 ## Code Style
 
 - Line length: 200 characters

--- a/README.md
+++ b/README.md
@@ -144,3 +144,19 @@ OTP_LABEL=amznit
 OTP_CODE=123456
 ```
 Look at the [example script](examples/otp-script-example.sh) to import script output into shell variables.
+
+## Creating a Release
+
+To create a new release:
+
+1. Bump the version in `otpversion.py`
+2. Bump the version in all occurrences in `pyproject.toml`
+3. Add a new release section in `CHANGELOG.md` following the existing format (this file is a template parsed by `tools/debian-changelog-generator.py` to create the DEB package)
+4. Merge changes to `main`
+5. Tag with the version number and push the tag:
+   ```
+   git tag X.Y.Z
+   git push origin X.Y.Z
+   ```
+
+The CI will automatically build and publish packages when a version tag is pushed.


### PR DESCRIPTION
Document the release process in README.md and CLAUDE.md.

Files to update for a release:
- `otpversion.py`
- `pyproject.toml` (both sections)
- `CHANGELOG.md`

Then tag and push to trigger CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)