### PR TITLE
Fix changelog generator and remove non-existent tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update github workflows to latest ubuntu and actions<!-- change line -->
 - Minor bump version for ci build<!-- change line -->
 
-## <!-- release tag -->[0.2.5] - 2025-12-16
-### Changed
-- Update python project to latest PEP standards<!-- change line -->
-- Update github workflows to latest ubuntu and actions<!-- change line -->
-- Minor bump version for ci build<!-- change line -->
-
-## <!-- release tag -->[0.2.4] - 2025-12-16
-### Changed
-- Update python project to latest PEP standards<!-- change line -->
-- Update github workflows to latest ubuntu and actions<!-- change line -->
-
 ## <!-- release tag -->[0.2.3] - 2022-07-02
 ### Changed
 - Fix a missing dependency python3-pkg-resources to start otpgui from docker containers<!-- change line -->


### PR DESCRIPTION
## Summary
- Remove entries for tags 0.2.5 and 0.2.4 which don't exist on GitHub
- Add `TagNotFoundError` exception with meaningful error messages
- Check API response status code and validate response structure

This fixes the debian-changelog-generator failure when using the API method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)