### PR TITLE
Release 0.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,38 @@
-virtualenv/
-.pytest_cache/
+# Python bytecode
 __pycache__/
+*.py[cod]
+*.so
+
+# Virtual environments
 .venv/
+virtualenv/
+
+# Packaging
 dist/
+*.egg-info/
+*.egg
+.eggs/
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Type checking
+.mypy_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*~
+
+# OS
+.DS_Store
+
+# Project specific
 .env
 **/artifacts/
 build/deb/debian/changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- changelog start -->
+## <!-- release tag -->[0.2.9] - 2025-12-18
+### Changed
+- Improve CI with linting, formatting checks, and caching<!-- change line -->
+- Improve test coverage from 1 to 8 tests<!-- change line -->
+- Add pytest-cov for coverage reporting<!-- change line -->
+
 ## <!-- release tag -->[0.2.8] - 2025-12-18
 ### Changed
 - Improve documentation<!-- change line -->

--- a/otpversion.py
+++ b/otpversion.py
@@ -1,1 +1,1 @@
-program_version = "0.2.8"
+program_version = "0.2.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "otpgui"
-version = "0.2.8"
+version = "0.2.9"
 description = "Otp Generator GUI with python"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ otpgui = "otpgui:main"
 
 [tool.poetry]
 name = "otpgui"
-version = "0.2.8"
+version = "0.2.9"
 description = "Otp Generator GUI with python"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Release 0.2.9

### Changed
- Improve CI: add linting (black, isort, flake8), caching, and `make fmt` target
- Improve test coverage: 1 → 8 tests (38% coverage), add pytest-cov
- Reorganize and expand `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)