### PR TITLE
Add user-friendly SOPS decryption error handling

### DIFF
--- a/otpgtk.py
+++ b/otpgtk.py
@@ -1,8 +1,11 @@
 import gi
-from gi.repository import Gdk, GLib, Gtk
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
+
+from gi.repository import Gdk, GLib, Gtk  # noqa: E402
+
+from otpgui import SopsDecryptionError  # noqa: E402
 
 
 class MyWindow(Gtk.Window):
@@ -52,7 +55,22 @@ class MyWindow(Gtk.Window):
             model = combo.get_model()
             SelectedLabel = model[tree_iter][0]
             self.otp.getlabel(SelectedLabel)
-            self.otp.getgenerator()
+            try:
+                self.otp.getgenerator()
+            except SopsDecryptionError as err:
+                self.show_error_dialog("Decryption Error", str(err))
+
+    def show_error_dialog(self, title, message):
+        dialog = Gtk.MessageDialog(
+            transient_for=self,
+            flags=0,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.OK,
+            text=title,
+        )
+        dialog.format_secondary_text(message)
+        dialog.run()
+        dialog.destroy()
 
     def on_otp_clicked(self, OtpCode):
         self.clipboard.set_text(self.OtpCode.get_label(), -1)


### PR DESCRIPTION
## Summary
- Add `SopsDecryptionError` exception with structured error message
- Show GPG key ID required for decryption (from .sops.yaml)
- Add GTK error dialogs for startup and runtime failures
- Handle label switching errors gracefully in GTK mode

## Test plan
- [x] All tests pass (`poetry run pytest`)
- [x] Code formatted (`make fmt`)
- [x] Verified script mode error output
- [ ] Manual test: GTK dialog on startup failure (requires X11)
- [ ] Manual test: GTK dialog on label switch failure (requires X11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)