### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- changelog start -->
+## <!-- release tag -->[0.3.2] - 2026-01-03
+### Changed
+- Minor changes and fixes to example scripts<!-- change line -->
+
 ## <!-- release tag -->[0.3.1] - 2026-01-02
 ### Added
 - Add examples to build a pure TUI scripted interface using dialog<!-- change line -->

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ OTP_CODE=123456
 ```
 Look at the [example script](examples/otp-script-example.sh) to import script output into shell variables.
 
+### Terminal UI Examples
+
+The [examples/OTPTUI.md](examples/OTPTUI.md) documentation describes terminal-based scripts using `dialog` that demonstrate how to build custom interfaces with `otpgui`'s scripted mode. These are useful for headless servers, SSH sessions, or environments without a graphical display.
+
 ## Creating a Release
 
 To create a new release:

--- a/examples/OTPTUI.md
+++ b/examples/OTPTUI.md
@@ -63,11 +63,7 @@ The script:
 
 ## Configuration
 
-By default, `otpmenu.sh` reads the OTP configuration from `$HOME/develop/otp/otp.yml`. Modify line 39 in the script to point to your own OTP configuration file:
-
-```bash
-yq .otp "/path/to/your/otp.yml" -o json |
-```
+`otpmenu.sh` automatically reads the OTP configuration path from `otpgui`'s settings file (`${XDG_CONFIG_HOME:-$HOME/.config}/otpgui/settings.yml`). No manual configuration is needed if `otpgui` is already set up.
 
 ## Integration with otpgui
 

--- a/examples/otpmenu.sh
+++ b/examples/otpmenu.sh
@@ -32,11 +32,23 @@ fi
 # Finally set the OTPTUI_SCRIPT location according to detected OTPTUI_PATH
 OTPTUI_SCRIPT="${OTPTUI_PATH}otptui.sh"
 
+OTPGUI_SETTINGS="${XDG_CONFIG_HOME:-$HOME/.config}/otpgui/settings.yml"
+if ! [[ -f "$OTPGUI_SETTINGS" ]]; then
+    echo "Error: OTP settings file not found (lookup: ${OTPGUI_SETTINGS:-null})"
+    exit 1
+fi
+
+OTP_CONFIG="$(yq .config_file "$OTPGUI_SETTINGS")"
+if ! [[ -f "$OTP_CONFIG" ]]; then
+    echo "Error: OTP config file not found (lookup: ${OTP_CONFIG:-null})"
+    exit 1
+fi
+
 TMPMENU="$(mktemp)"
 TMPOTP="$(mktemp)"
 (
     echo "--menu otp 50 70 30 \\"
-    yq .otp "$HOME/develop/otp/otp.yml" -o json |
+    yq .otp "$OTP_CONFIG" -o json |
         jq -Mrcs '.[] | to_entries | sort_by(.key) | map([.key, .value.name] | join(";"))[]' |
         awk -F';' 'NR>1{print p" \\"}{p="\t\""$1"\" \""$2"\""}END{print p}'
 ) >"$TMPMENU"

--- a/otpversion.py
+++ b/otpversion.py
@@ -1,1 +1,1 @@
-program_version = "0.3.1"
+program_version = "0.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "otpgui"
-version = "0.3.1"
+version = "0.3.2"
 description = "Otp Generator GUI with python"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ otpgui = "otpgui:main"
 
 [tool.poetry]
 name = "otpgui"
-version = "0.3.1"
+version = "0.3.2"
 description = "Otp Generator GUI with python"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- Fix otpmenu.sh to read OTP config path from settings.yml instead of hardcoded path
- Update OTPTUI.md configuration section to reflect automatic config detection
- Add Terminal UI Examples reference to main README
- Bump version to 0.3.2

## Test plan
- [x] Verify otpmenu.sh reads config from `~/.config/otpgui/settings.yml`
- [x] Verify error messages display correctly when config files are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)