### PR TITLE
ci: add system libraries to release workflow

### DIFF
--- a/.github/workflows/releasepkg.yml
+++ b/.github/workflows/releasepkg.yml
@@ -16,6 +16,10 @@ jobs:
         uses: abatilo/actions-poetry@v4
         with:
           poetry-version: '2.2.1'
+      - name: Install system libraries
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libgirepository1.0-dev libgtk-3-dev libcairo2-dev
       - name: Install dependencies
         run: poetry install
       - name: Validate version matches tag


### PR DESCRIPTION
## Summary
Add system library installation step to release workflow to support `poetry install` with pycairo dependency.

Required for version validation feature added in #41.

## Changes
- Add `libgirepository1.0-dev`, `libgtk-3-dev`, `libcairo2-dev` installation before `poetry install`