### PR TITLE
ci: fix system libraries in release workflow

### DIFF
--- a/.github/workflows/releasepkg.yml
+++ b/.github/workflows/releasepkg.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install system libraries
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install libgirepository1.0-dev libgtk-3-dev libcairo2-dev
+          sudo apt-get -y install libgirepository1.0-dev libgtk-3-dev libgirepository-2.0-dev
       - name: Install dependencies
         run: poetry install
       - name: Validate version matches tag


### PR DESCRIPTION
Match system libraries with test workflow (add libgirepository-2.0-dev).